### PR TITLE
Remove version attribute from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "justpark/php-flagr",
-    "version": "1.0.10",
     "description": "",
     "keywords": [
         "swagger",


### PR DESCRIPTION
Don't think I can see my new tag because of this attribute, can be omitted apparently

https://getcomposer.org/doc/04-schema.md#version

Similar issue
https://github.com/composer/composer/issues/8947